### PR TITLE
Add package support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.23.4",
  "tungstenite",
- "webpki-roots",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -599,10 +599,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "flate2"
-version = "1.0.26"
+name = "filetime"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1752,7 +1764,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.22.6",
  "winreg",
 ]
 
@@ -1845,7 +1857,7 @@ checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.3",
  "sct",
 ]
 
@@ -1856,6 +1868,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
  "base64 0.21.2",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2272,6 +2294,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2571,9 +2604,8 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 [[package]]
 name = "typst"
 version = "0.7.0"
-source = "git+https://github.com/typst/typst#2f81089995c87efdbce6c94bb29647cd1f213cfd"
+source = "git+https://github.com/typst/typst?tag=v0.7.0#da8367e189b02918a8fe1a98fd3059fd11a82cd9"
 dependencies = [
- "base64 0.21.2",
  "bitflags 2.4.0",
  "bytemuck",
  "comemo",
@@ -2611,8 +2643,6 @@ dependencies = [
  "unicode-segmentation",
  "unscanny",
  "usvg",
- "xmlparser",
- "xmlwriter",
  "xmp-writer",
 ]
 
@@ -2633,7 +2663,7 @@ dependencies = [
 [[package]]
 name = "typst-library"
 version = "0.7.0"
-source = "git+https://github.com/typst/typst#2f81089995c87efdbce6c94bb29647cd1f213cfd"
+source = "git+https://github.com/typst/typst?tag=v0.7.0#da8367e189b02918a8fe1a98fd3059fd11a82cd9"
 dependencies = [
  "az",
  "chinese-number",
@@ -2672,7 +2702,7 @@ dependencies = [
 [[package]]
 name = "typst-macros"
 version = "0.7.0"
-source = "git+https://github.com/typst/typst#2f81089995c87efdbce6c94bb29647cd1f213cfd"
+source = "git+https://github.com/typst/typst?tag=v0.7.0#da8367e189b02918a8fe1a98fd3059fd11a82cd9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2683,7 +2713,7 @@ dependencies = [
 [[package]]
 name = "typst-syntax"
 version = "0.7.0"
-source = "git+https://github.com/typst/typst#2f81089995c87efdbce6c94bb29647cd1f213cfd"
+source = "git+https://github.com/typst/typst?tag=v0.7.0#da8367e189b02918a8fe1a98fd3059fd11a82cd9"
 dependencies = [
  "comemo",
  "ecow",
@@ -2809,6 +2839,22 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "ureq"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b11c96ac7ee530603dcdf68ed1557050f374ce55a5a07193ebf8cbc9f8927e9"
+dependencies = [
+ "base64 0.21.2",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls 0.21.6",
+ "rustls-webpki 0.100.1",
+ "url",
+ "webpki-roots 0.23.1",
+]
 
 [[package]]
 name = "url"
@@ -3034,6 +3080,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
+dependencies = [
+ "rustls-webpki 0.100.1",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3163,12 +3218,17 @@ dependencies = [
  "bytemuck",
  "cargo_metadata",
  "comemo",
+ "flate2",
  "image",
  "protocol",
+ "same-file",
+ "siphasher",
+ "tar",
  "thiserror",
  "time",
  "typst",
  "typst-library",
+ "ureq",
 ]
 
 [[package]]
@@ -3176,6 +3236,15 @@ name = "writeable"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60e49e42bdb1d5dc76f4cd78102f8f0714d32edfa3efb82286eb0f0b1fc0da0f"
+
+[[package]]
+name = "xattr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "xmlparser"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ To set up the working environment, create a directory with the following items:
 
 To run, CD into this directory, set `DISCORD_TOKEN` to your bot token, and run the `bot` binary (not the `worker` binary that's also in the directory).
 
+To allow use of packages, set `CACHE_DIRECTORY` to a directory to download and read packages from.
+
 ## License
 
 AGPL. Use `?source` to get a link to the source from deployments of the bot.

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -8,12 +8,17 @@ ariadne = { version = "0.3", default_features = false }
 bincode = "1"
 bytemuck = "1"
 comemo = "0.3"
+flate2 = "1.0.27"
 image = { version = "0.24", default_features = false, features = ["png"] }
 protocol = { path = "../protocol" }
+same-file = "1.0.6"
+siphasher = "0.3.10"
+tar = "0.4.40"
 thiserror = "1"
 time = "0.3"
-typst = { git = "https://github.com/typst/typst" }
-typst-library = { git = "https://github.com/typst/typst" }
+typst = { git = "https://github.com/typst/typst", tag = "v0.7.0" }
+typst-library = { git = "https://github.com/typst/typst", tag = "v0.7.0" }
+ureq = "2.7.1"
 
 [build-dependencies]
 cargo_metadata = "0.15"

--- a/worker/build.rs
+++ b/worker/build.rs
@@ -18,7 +18,8 @@ fn main() {
 		.as_ref()
 		.unwrap()
 		.repr
-		.strip_prefix("git+https://github.com/typst/typst#")
+		.split("#")
+		.last()
 		.unwrap();
 
 	println!("cargo:rustc-env=TYPST_VERSION={version}");

--- a/worker/src/file.rs
+++ b/worker/src/file.rs
@@ -1,0 +1,87 @@
+use std::cell::OnceCell;
+use std::fs;
+use std::hash::Hash;
+use std::path::{Path, PathBuf};
+
+use same_file::Handle;
+use siphasher::sip128::{Hasher128, SipHasher13};
+use typst::diag::{FileError, FileResult};
+use typst::eval::Bytes;
+use typst::syntax::{FileId, Source};
+
+/// Holds canonical data for all paths pointing to the same entity.
+///
+/// Both fields can be populated if the file is both imported and read().
+pub struct PathSlot {
+	/// The slot's canonical file id.
+	id: FileId,
+	/// The slot's path on the system.
+	system_path: PathBuf,
+	/// The lazily loaded source file for a path hash.
+	source: OnceCell<FileResult<Source>>,
+	/// The lazily loaded buffer for a path hash.
+	buffer: OnceCell<FileResult<Bytes>>,
+}
+
+impl PathSlot {
+	pub fn new(id: FileId, system_path: PathBuf) -> Self {
+		Self {
+			id,
+			system_path,
+			source: OnceCell::new(),
+			buffer: OnceCell::new(),
+		}
+	}
+	pub fn source(&self) -> FileResult<Source> {
+		self
+			.source
+			.get_or_init(|| {
+				let buf = read(&self.system_path)?;
+				let text = decode_utf8(buf)?;
+				Ok(Source::new(self.id, text))
+			})
+			.clone()
+	}
+
+	pub fn file(&self) -> FileResult<Bytes> {
+		self
+			.buffer
+			.get_or_init(|| read(&self.system_path).map(Bytes::from))
+			.clone()
+	}
+}
+
+/// A hash that is the same for all paths pointing to the same entity.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub struct PathHash(u128);
+
+impl PathHash {
+	pub fn new(path: &Path) -> FileResult<Self> {
+		let f = |e| FileError::from_io(e, path);
+		let handle = Handle::from_path(path).map_err(f)?;
+		let mut state = SipHasher13::new();
+		handle.hash(&mut state);
+		Ok(Self(state.finish128().as_u128()))
+	}
+}
+
+/// Read a file.
+fn read(path: &Path) -> FileResult<Vec<u8>> {
+	let f = |e| FileError::from_io(e, path);
+	if fs::metadata(path).map_err(f)?.is_dir() {
+		Err(FileError::IsDirectory)
+	} else {
+		fs::read(path).map_err(f)
+	}
+}
+
+/// Decode UTF-8 with an optional BOM.
+fn decode_utf8(buf: Vec<u8>) -> FileResult<String> {
+	Ok(if buf.starts_with(b"\xef\xbb\xbf") {
+		// Remove UTF-8 BOM.
+		std::str::from_utf8(&buf[3..])?.into()
+	} else {
+		// Assume UTF-8.
+		String::from_utf8(buf)?
+	})
+}

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -7,6 +7,8 @@ use protocol::{Request, Response};
 use crate::render::render;
 use crate::sandbox::Sandbox;
 
+mod file;
+mod package;
 mod render;
 mod sandbox;
 

--- a/worker/src/package.rs
+++ b/worker/src/package.rs
@@ -1,0 +1,53 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use typst::diag::{PackageError, PackageResult};
+use typst::syntax::PackageSpec;
+
+/// Make a package available in the on-disk cache.
+pub fn prepare_package(spec: &PackageSpec) -> PackageResult<PathBuf> {
+	let dir = PathBuf::from(format!(
+		"{}/{}/{}/{}",
+		std::env::var("CACHE_DIRECTORY").expect("need `CACHE_DIRECTORY` env var"),
+		spec.namespace,
+		spec.name,
+		spec.version
+	));
+
+	// Download from network if it doesn't exist yet.
+	if spec.namespace == "preview" && !dir.exists() {
+		download_package(spec, &dir)?;
+	}
+
+	if dir.exists() {
+		return Ok(dir);
+	}
+
+	Err(PackageError::NotFound(spec.clone()))
+}
+
+/// Download a package over the network.
+fn download_package(spec: &PackageSpec, package_dir: &Path) -> PackageResult<()> {
+	// The `@preview` namespace is the only namespace that supports on-demand
+	// fetching.
+	assert_eq!(spec.namespace, "preview");
+
+	let url = format!(
+		"https://packages.typst.org/preview/{}-{}.tar.gz",
+		spec.name, spec.version
+	);
+
+	let reader = match ureq::get(&url).call() {
+		Ok(response) => response.into_reader(),
+		Err(ureq::Error::Status(404, _)) => return Err(PackageError::NotFound(spec.clone())),
+		Err(_) => return Err(PackageError::NetworkFailed),
+	};
+
+	let decompressed = flate2::read::GzDecoder::new(reader);
+	tar::Archive::new(decompressed)
+		.unpack(package_dir)
+		.map_err(|_| {
+			fs::remove_dir_all(package_dir).ok();
+			PackageError::MalformedArchive
+		})
+}

--- a/worker/src/sandbox.rs
+++ b/worker/src/sandbox.rs
@@ -1,3 +1,6 @@
+use std::cell::{RefCell, RefMut};
+use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use comemo::Prehashed;
@@ -5,6 +8,10 @@ use typst::diag::{FileError, FileResult};
 use typst::eval::{Bytes, Library};
 use typst::font::{Font, FontBook};
 use typst::syntax::{FileId, Source};
+use typst::util::PathExt;
+
+use crate::file::{PathHash, PathSlot};
+use crate::package::prepare_package;
 
 pub struct Sandbox {
 	library: Prehashed<Library>,
@@ -36,6 +43,8 @@ pub struct WithSource {
 	sandbox: Arc<Sandbox>,
 	source: Source,
 	time: time::OffsetDateTime,
+	hashes: RefCell<HashMap<FileId, FileResult<PathHash>>>,
+	paths: RefCell<HashMap<PathHash, PathSlot>>,
 }
 
 impl Sandbox {
@@ -54,6 +63,8 @@ impl Sandbox {
 			sandbox: self,
 			source: make_source(source),
 			time: get_time(),
+			hashes: RefCell::default(),
+			paths: RefCell::default(),
 		}
 	}
 }
@@ -61,6 +72,37 @@ impl Sandbox {
 impl WithSource {
 	pub fn source(&self) -> &Source {
 		&self.source
+	}
+
+	fn slot(&self, id: FileId) -> FileResult<RefMut<PathSlot>> {
+		let mut system_path = PathBuf::new();
+		let hash = self
+			.hashes
+			.borrow_mut()
+			.entry(id)
+			.or_insert_with(|| {
+				// Determine the root path relative to which the file path
+				// will be resolved.
+				let root = match id.package() {
+					Some(spec) => prepare_package(spec)?,
+					None => PathBuf::from("."),
+				};
+
+				// Join the path to the root. If it tries to escape, deny
+				// access. Note: It can still escape via symlinks.
+				system_path = root.join_rooted(id.path()).ok_or(FileError::AccessDenied)?;
+
+				PathHash::new(&system_path)
+			})
+			.clone()?;
+
+		Ok(RefMut::map(self.paths.borrow_mut(), |paths| {
+			paths
+				.entry(hash)
+				// This will only trigger if the `or_insert_with` above also
+				// triggered.
+				.or_insert_with(|| PathSlot::new(id, system_path))
+		}))
 	}
 }
 
@@ -76,6 +118,8 @@ impl typst::World for WithSource {
 	fn source(&self, id: FileId) -> FileResult<Source> {
 		if id == self.source.id() {
 			Ok(self.source.clone())
+		} else if id.package().is_some() {
+			self.slot(id)?.source()
 		} else {
 			Err(FileError::NotFound(id.path().into()))
 		}
@@ -90,7 +134,11 @@ impl typst::World for WithSource {
 	}
 
 	fn file(&self, id: FileId) -> FileResult<Bytes> {
-		Err(FileError::NotFound(id.path().into()))
+		if id.package().is_some() {
+			self.slot(id)?.file()
+		} else {
+			Err(FileError::NotFound(id.path().into()))
+		}
 	}
 
 	fn today(&self, offset: Option<i64>) -> Option<typst::eval::Datetime> {


### PR DESCRIPTION
- Also changed to use git tags to target the correct Typst release dependency in `cargo.toml` instead of the latest commit