### PR TITLE
Update Dockerfile and docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM rust:1.72-bullseye AS build
 COPY . /typst-bot
 
 WORKDIR /typst-bot
-RUN cargo build --release --all
+RUN cargo build --release --all --config git-fetch-with-cli=true
 
 
 # ====== Run stage ======

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,25 @@
 ---
 
+name: typst-bot
+version: "3.8"
 services:
-    typst-bot:
-        container_name: typst-bot
+    bot:
+        # This service is built using the Dockerfile in the current directory.
         build: .
-        env_file: .env
+        # This service is always restarted if it ever shuts down (unless stopped manually).
         restart: always
+        # The `DISCORD_TOKEN` variable is set within the container to whatever value `DISCORD_TOKEN`
+        # has when Compose is run. It is not saved in the image. Compose will automatically grab its
+        # value from `.env` or the host OS. `?:error` makes it mandatory.
+        environment:
+            - DISCORD_TOKEN=${DISCORD_TOKEN?:error}
+        # The `/bot/sqlite` and `/bot/cache` directories are mapped to volumes.
+        volumes:
+            - sqlite:/bot/sqlite
+            - cache:/bot/cache
+
+# SQLite database for tags and package cache are stored in named volumes managed by Docker. As long
+# as the volumes are kept in between container rebuilds, they won't need to be recreated.
+volumes:
+    sqlite:
+    cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,8 @@
-{
-	"services": {
-		"typst-bot": {
-			"build": {
-				"dockerfile": "Dockerfile",
-				"target": "prod",
-			},
-			"environment": [
-				"CACHE_DIRECTORY=/bot/cache",
-			],
-			"env_file": ".env",
-			"container_name": "typst-bot",
-			"restart": "always",
-		},
-	},
-}
+---
+
+services:
+    typst-bot:
+        container_name: typst-bot
+        build: .
+        env_file: .env
+        restart: always


### PR DESCRIPTION
This closes #11. I'm _pretty sure_ this is what you're looking for. 🙂 I did a little bit extra, because why not.

The bot seemed to work fine when I tested it with my own token and test server, including with tags ([screenshot](https://github.com/mattfbacon/typst-bot/assets/43387454/8109b73c-c472-4db0-849c-753579bbd26e)). The final Docker image has been brought down from 215.67 MB to 179.63 MB. Not a massive change, but nothing to complain about for sure 😄

**Dockerfile:**

- Add `DB_PATH=/bot/db.sqlite` as an environment variable for the image.
- Remove Git LFS-related commands, since it looks like the fonts no longer use LFS.
- Change `RUN git clone` in the build stage to `COPY . /typst-bot`. Now, the Docker image uses the current worktree's source code instead of the current upstream/master branch state.
- Use `debian:bullseye-slim` instead of just `debian` for the final build image. The build stage is updated accordingly.
- Reduce the amount of layers in the final stage slightly to reduce the final size of the image.

**docker-compose.yml:**

- Convert `.yml` file into actual YAML (was there a reason it was JSON before? Unsure on this one).
- Remove unnecessary options from configuration:
  - Multi-stage builds automatically only take the final stage, and so `--target prod` is redundant.
  - `environment` is not needed because `CACHE_DIRECTORY` is set in the image itself.

---

One other thing that may be worth noting is that, since the DB is stored within the container, it won't persist between restarts of the image. Setting it up as a volume might be preferable. But that's something for another day.