### PR TITLE
Add support for '/tag' autocomplete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2703,6 +2703,7 @@ dependencies = [
  "poise",
  "protocol",
  "rusqlite",
+ "serde",
  "serenity",
  "thiserror",
  "tokio",

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -12,6 +12,7 @@ poise = { version = "0.5", git = "https://github.com/serenity-rs/poise", rev = "
 	"time",
 ] }
 protocol = { path = "../protocol" }
+serde = { version = "1", features = ["derive"] }
 serenity = { version = "0.11", default_features = false, features = [
 	"rustls_backend",
 ] }


### PR DESCRIPTION
Draft because I haven't tested at all yet, but the code compiles at least (and _should_ be correct). Will test over the next few days.

Based on previous work at https://github.com/PgBiel/mentoriabot/blob/main/crates/bot/src/commands/autocomplete.rs