### PR TITLE
Strip ANSI escape codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,6 +2175,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2659,6 +2668,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serenity",
+ "strip-ansi-escapes",
  "thiserror",
  "tokio",
  "tracing",
@@ -2933,6 +2943,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2943,6 +2959,26 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "walkdir"

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -11,11 +11,12 @@ poise = { version = "0.6", git = "https://github.com/serenity-rs/poise", default
 	"cache",
 ] }
 protocol = { path = "../protocol" }
+rusqlite = { version = "0.29", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serenity = { version = "0.12", default_features = false, features = [
 	"rustls_backend",
 ] }
-rusqlite = { version = "0.29", features = ["bundled"] }
+strip-ansi-escapes = "0.2.0"
 thiserror = "1"
 tokio = { version = "1", features = ["rt", "macros", "sync"] }
 tracing = "0.1"


### PR DESCRIPTION
This change permits users to highlight code blocks using ANSI escape codes while still compiling the code correctly.

This is useful because Discord does not highlight Typst code in any way and highlighting is nice.

EDIT: I have now created [typst-ansi-hl](https://github.com/frozolotl/typst-ansi-hl), which allows creating such highlighted code blocks.