### PR TITLE
Add CJK & Emoji support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2941,6 +2941,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "typst-dev-assets"
+version = "0.13.1"
+source = "git+https://github.com/typst/typst-dev-assets.git?rev=995986da#995986dacab11558ea2d7c3a08dd7ad7197743d0"
+
+[[package]]
 name = "typst-eval"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3787,6 +3792,7 @@ dependencies = [
  "ttf-parser",
  "typst",
  "typst-assets",
+ "typst-dev-assets",
  "typst-render",
  "ureq",
  "zune-inflate",

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -16,6 +16,7 @@ time = "0.3"
 ttf-parser = "0.24"
 typst = "0.13"
 typst-assets = { version = "0.13", features = ["fonts"] }
+typst-dev-assets = { git = "https://github.com/typst/typst-dev-assets.git", rev = "995986da" }
 typst-render = "0.13"
 
 # downloading packages

--- a/crates/worker/src/sandbox.rs
+++ b/crates/worker/src/sandbox.rs
@@ -44,6 +44,7 @@ pub struct Sandbox {
 
 fn fonts() -> Vec<Font> {
 	typst_assets::fonts()
+		.chain(typst_dev_assets::fonts())
 		.flat_map(|bytes| {
 			let buffer = Bytes::new(bytes);
 			let face_count = ttf_parser::fonts_in_collection(&buffer).unwrap_or(1);


### PR DESCRIPTION
# Goal
Support CJK & Emoji rendering

# Problem
<img width="798" height="723" alt="image" src="https://github.com/user-attachments/assets/7884857e-0b6d-459b-aa36-ceb4163753e6" />

Input codeblock:

```rust
#import "@preview/deckz:0.2.0"
#deckz.render("QD", format: "large")

🗼🇪🇺 今朝 ありがとうございます 조선글
```

# Solution
Add [typst-dev-assets](https://github.com/typst/typst-dev-assets/) as dependency

# Result
<img width="827" height="714" alt="image" src="https://github.com/user-attachments/assets/0d3d8dd7-d560-409f-9b8b-4f706ca057dc" />
