### PR TITLE
refactor: fix FromAsCasing Warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY crates crates
 RUN cargo build --release --workspace --config git-fetch-with-cli=true
 
 # ============ Run Stage ============
-FROM debian:trixie-slim as run
+FROM debian:trixie-slim AS run
 
 WORKDIR /bot
 CMD [ "/bot/typst-bot" ]


### PR DESCRIPTION
I tried to build a docker image, and I received a warning, whose message is self-explaining.

<img width="918" height="625" alt="image" src="https://github.com/user-attachments/assets/0e083d51-bb6a-4b95-8a0f-99894913d460" />

<img width="915" height="628" alt="image" src="https://github.com/user-attachments/assets/7b3912bb-1fb6-4faf-8587-88649b5b68de" />

related: cypress-io/cypress-docker-images issue 1139